### PR TITLE
Add GNUmakefile and target to generate AUTHORS.md file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+David Cantrell <dcantrell@redhat.com> David Cantrell <dcantrell@burdell.org>
+Jan Kolarik <jkolarik@redhat.com> kolage <110612307+jan-kolarik@users.noreply.github.com>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,7 @@
+Authors
+=======
+
+- David Cantrell <dcantrell@redhat.com>
+
+- Jan Kolarik <jkolarik@redhat.com>
+

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,25 @@
+# This GNU make Makefile is intended as a helper.  meson is used for
+# the actual build and configuration, but this GNUmakefile provides
+# some useful targets for development and release purposes.  Type
+# "gmake help" for more details.  It is called GNUmakefile to indicate
+# it requires GNU make.
+
+all:
+	@echo "Type 'gmake help' for targets."
+
+authors:
+	echo "Authors" > AUTHORS.md
+	echo "=======" >> AUTHORS.md
+	echo >> AUTHORS.md
+	git log --pretty="%aN <%aE>" | env LC_ALL=C sort -u | sed -e 's|^|- |g;G' >> AUTHORS.md
+
+help:
+	@echo "libpkgmanifest helper GNUmakefile"
+	@echo "The source tree uses meson(1) for building and testing, but this GNUmakefile"
+	@echo "is intended as a simple helper for the common steps."
+	@echo
+	@echo "    authors           Generate a new AUTHORS.md file"
+
+# Quiet errors about target arguments not being targets
+%:
+	@true


### PR DESCRIPTION
The GNUmakefile is also going to serve as a harness to build the project with meson, but that will be a separate commit.  This one adds the GNUmakefile so that AUTHORS.md can be updated periodically.

Resolves: SWM-6442