### PR TITLE
build: Turn compiler warnings into errors only for our code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(YAMLCPP REQUIRED IMPORTED_TARGET GLOBAL yaml-cpp)
 pkg_check_modules(RPM REQUIRED IMPORTED_TARGET GLOBAL rpm)
 
-add_compile_options(-Wall -Wextra -Werror)
+add_compile_options(-Wall -Wextra)
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ file(GLOB_RECURSE libpkgmanifest_SOURCES *.cpp)
 list(APPEND libpkgmanifest_PC_REQUIRES)
 list(APPEND libpkgmanifest_PC_REQUIRES_PRIVATE)
 
+add_compile_options(-Werror)
 include_directories(.)
 
 add_library(libpkgmanifest SHARED ${libpkgmanifest_SOURCES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ pkg_check_modules(GMOCK REQUIRED gmock)
 
 file(GLOB_RECURSE TEST_libpkgmanifest_SOURCES *.cpp)
 
+add_compile_options(-Werror)
 include_directories(.)
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/src)


### PR DESCRIPTION
Building with GCC 16 failed on i686 architecture:

    /builddir/build/BUILD/libpkgmanifest-0.5.9-build/libpkgmanifest-0.5.9/redhat-linux-build/bindings/python/libpkgmanifest/CMakeFiles/python3_common.dir/commonPYTHON_wrap.cxx: In function ‘void SWIG_TypeClientData(swig_type_info*, void*)’:
    /builddir/build/BUILD/libpkgmanifest-0.5.9-build/libpkgmanifest-0.5.9/redhat-linux-build/bindings/python/libpkgmanifest/CMakeFiles/python3_common.dir/commonPYTHON_wrap.cxx:692:37: error: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Werror=sign-compare]
      692 |     for (cast = head; (cast - head) <= head->value; cast++) {
	  |                       ~~~~~~~~~~~~~~^~~~~~~~~~~~~~

The cause is a bug in Swig-4.4.1 <https://github.com/swig/swig/issues/3323>. The bug is triggered by adding -Wextra -Werror to all compiler invocation, stricter GCC, and building on 32-bit platforms where a ptrdiff_t type has the same rank as the int type.

This patch works around the compiler warning by only applying the -Werror option to code we maintain. Particullary, not applying to Swig-generated code. In my opinion, this is more sustainable approach than adding -Wno-warn-... exceptions to bindings/CMakeLists.txt whenever the C++ compiler or Swig changes.

Resolve: https://bugzilla.redhat.com/show_bug.cgi?id=2434767

A Fedora scratch build applying this fix <https://koji.fedoraproject.org/koji/taskinfo?taskID=141685236>.