### PR TITLE
Configure packit to use caret notation for postrelease snapshots

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,6 +1,8 @@
 upstream_tag_template: v{version}
 
 specfile_path: libpkgmanifest.spec
+version_suffix: "^{PACKIT_PROJECT_SNAPSHOTID}"
+update_release: false
 
 files_to_sync:
   - libpkgmanifest.spec


### PR DESCRIPTION
This ensures the build of that specific version is considered newer than any other regular release of it.

For rpm-software-management/ci-dnf-stack#1843

Example build: https://copr.fedorainfracloud.org/coprs/amatej/dnf-nightly/build/10282547/