### PR TITLE
Add a trailing newline to serialized YAML

### DIFF
--- a/src/impl/common/yaml/yamlserializer.cpp
+++ b/src/impl/common/yaml/yamlserializer.cpp
@@ -18,7 +18,7 @@ std::string YamlSerializer::to_string(const IYamlNode & node) const {
     if (!yaml_node) {
         throw std::runtime_error("Node is not an instance of YamlNode");
     }
-    return yaml_node->get_node().as<std::string>();
+    return yaml_node->get_node().as<std::string>() + "\n";
 }
 
 void YamlSerializer::to_file(const IYamlNode & node, const std::string & path) const {
@@ -31,7 +31,7 @@ void YamlSerializer::to_file(const IYamlNode & node, const std::string & path) c
     file_stream.exceptions(std::ofstream::badbit | std::ofstream::failbit);
     try {
         file_stream.open(path);
-        file_stream << yaml_node->get_node();
+        file_stream << yaml_node->get_node() << "\n";
     } catch (std::ofstream::failure & ex) {
         throw FileOutputError(ex.what());
     }

--- a/test/api/manifest/serializertest.cpp
+++ b/test/api/manifest/serializertest.cpp
@@ -60,7 +60,8 @@ data:
         location: another/dir/file.here
         checksum: sha256:qpwoeiru
         size: 97643154
-        evr: 9.9-1.r3)";
+        evr: 9.9-1.r3
+)";
 
     Repository repository1;
     repository1.set_id("repo1");
@@ -142,7 +143,8 @@ TEST_F(ApiManifestSerializerTest, SerializeEmptyManifest) {
 version: 0.2.2
 data:
   repositories: ~
-  packages: ~)";
+  packages: ~
+)";
 
     Manifest manifest;
     Serializer serializer;

--- a/test/impl/common/yaml/yamlserializertest.cpp
+++ b/test/impl/common/yaml/yamlserializertest.cpp
@@ -40,7 +40,7 @@ TEST_F(YamlSerializerTest, SerializeSimpleYamlToFile) {
     std::ifstream file_stream(file_path);
     std::string content((std::istreambuf_iterator<char>(file_stream)), std::istreambuf_iterator<char>());
 
-    EXPECT_EQ("value", content);
+    EXPECT_EQ("value\n", content);
 }
 
 TEST_F(YamlSerializerTest, SerializeSimpleYamlToFileWithUnknownNodeImplThrowsException) {
@@ -64,7 +64,7 @@ TEST_F(YamlSerializerTest, SerializeSimpleYamlToString) {
     YamlSerializer serializer;
     auto content = serializer.to_string(node);
 
-    EXPECT_EQ("value", content);
+    EXPECT_EQ("value\n", content);
 }
 
 TEST_F(YamlSerializerTest, SerializeSimpleYamlToStringWithUnknownNodeImplThrowsException) {

--- a/test/impl/manifest/operations/serializerfactorytest.cpp
+++ b/test/impl/manifest/operations/serializerfactorytest.cpp
@@ -73,7 +73,8 @@ data:
         location: another/dir/file.here
         checksum: sha256:qpwoeiru
         size: 97643154
-        evr: 9.9-1.r3)";
+        evr: 9.9-1.r3
+)";
 
     std::vector<std::string> empty_vector;
 


### PR DESCRIPTION
Per https://github.com/jbeder/yaml-cpp/issues/428, yaml-cpp does not add a trailing newline when serializing. However, we always want trailing newlines for manifests since they will be multiline documents.