### PR TITLE
Improve error messages for missing keys

### DIFF
--- a/src/impl/common/yaml/yamlnode.cpp
+++ b/src/impl/common/yaml/yamlnode.cpp
@@ -14,6 +14,8 @@ YamlNode::YamlNode() {}
 
 YamlNode::YamlNode(const YAML::Node & node) : node(node) {}
 
+YamlNode::YamlNode(const YAML::Node & node, const std::string & path) : node(node), path(path) {}
+
 bool YamlNode::has(const std::string & key) const {
     return node.IsMap() && bool(node[key]);
 }
@@ -21,9 +23,9 @@ bool YamlNode::has(const std::string & key) const {
 std::unique_ptr<IYamlNode> YamlNode::get(const std::string & key) const {
     auto inner_node = node[key];
     if (!inner_node) {
-        throw YamlUnknownKeyError("Unknown key: " + key);
+        throw YamlUnknownKeyError("Missing field: " + child_path(key));
     }
-    return std::make_unique<YamlNode>(std::move(inner_node));
+    return std::make_unique<YamlNode>(std::move(inner_node), child_path(key));
 }
 
 std::string YamlNode::as_string() const {
@@ -49,7 +51,8 @@ uint64_t YamlNode::as_uint64() const {
 std::vector<std::unique_ptr<IYamlNode>> YamlNode::as_list() const {
     std::vector<std::unique_ptr<IYamlNode>> nodes;
     for (std::size_t i = 0; i < node.size(); i++) {
-        nodes.push_back(std::make_unique<YamlNode>(node[i]));
+        auto element_path = path + "[" + std::to_string(i) + "]";
+        nodes.push_back(std::make_unique<YamlNode>(node[i], element_path));
     }
     return nodes;
 }
@@ -57,7 +60,8 @@ std::vector<std::unique_ptr<IYamlNode>> YamlNode::as_list() const {
 std::map<std::string, std::unique_ptr<IYamlNode>> YamlNode::as_map() const {
     std::map<std::string, std::unique_ptr<IYamlNode>> nodes;
     for (auto it = node.begin(); it != node.end(); it++) {
-        nodes.insert({it->first.as<std::string>(), std::make_unique<YamlNode>(it->second)});
+        auto key = it->first.as<std::string>();
+        nodes.insert({key, std::make_unique<YamlNode>(it->second, child_path(key))});
     }
     return nodes;
 }
@@ -96,6 +100,13 @@ void YamlNode::insert(const std::string & key, std::unique_ptr<IYamlNode> value)
 
 const YAML::Node & YamlNode::get_node() const {
     return node;
+}
+
+std::string YamlNode::child_path(const std::string & key) const {
+    if (path.empty()) {
+        return key;
+    }
+    return path + "." + key;
 }
 
 }  // namespace libpkgmanifest::internal::common

--- a/src/impl/common/yaml/yamlnode.hpp
+++ b/src/impl/common/yaml/yamlnode.hpp
@@ -23,6 +23,7 @@ class YamlNode : public IYamlNodeInternal {
 public:
     YamlNode();
     YamlNode(const YAML::Node & node);
+    YamlNode(const YAML::Node & node, const std::string & path);
 
     virtual bool has(const std::string & key) const override;
     virtual std::unique_ptr<IYamlNode> get(const std::string & key) const override;
@@ -56,7 +57,10 @@ private:
         }
     }
 
+    std::string child_path(const std::string & key) const;
+
     YAML::Node node;
+    std::string path;
 };
 
 }  // namespace libpkgmanifest::internal::common

--- a/test/impl/common/yaml/yamlnodetest.cpp
+++ b/test/impl/common/yaml/yamlnodetest.cpp
@@ -17,6 +17,47 @@ TEST(YamlNodeTest, ParseNonExistingItemFromYamlThrowsAnException) {
     EXPECT_THROW(node.get("key"), YamlUnknownKeyError);
 }
 
+TEST(YamlNodeTest, MissingKeyErrorContainsFullPath) {
+    YamlNode node(YAML::Load("packages:\n  install:\n    - name: pkg1"));
+    try {
+        node.get("packages")->get("install")->as_list()[0]->get("missing");
+        FAIL() << "Expected YamlUnknownKeyError";
+    } catch (const YamlUnknownKeyError & ex) {
+        EXPECT_THAT(std::string(ex.what()), ::testing::HasSubstr("packages.install[0].missing"));
+    }
+}
+
+TEST(YamlNodeTest, MissingKeyErrorAtTopLevelShowsKeyOnly) {
+    YamlNode node(YAML::Load("foo: bar"));
+    try {
+        node.get("missing");
+        FAIL() << "Expected YamlUnknownKeyError";
+    } catch (const YamlUnknownKeyError & ex) {
+        EXPECT_THAT(std::string(ex.what()), ::testing::HasSubstr("Missing field: missing"));
+    }
+}
+
+TEST(YamlNodeTest, MissingKeyErrorAtNestedLevelShowsFullPath) {
+    YamlNode node(YAML::Load("data:\n  repos:\n    id: 1"));
+    try {
+        node.get("data")->get("repos")->get("nonexistent");
+        FAIL() << "Expected YamlUnknownKeyError";
+    } catch (const YamlUnknownKeyError & ex) {
+        EXPECT_THAT(std::string(ex.what()), ::testing::HasSubstr("data.repos.nonexistent"));
+    }
+}
+
+TEST(YamlNodeTest, MapEntriesCarryPath) {
+    YamlNode node(YAML::Load("x86_64:\n  - name: pkg1"));
+    auto map = node.as_map();
+    try {
+        map["x86_64"]->as_list()[0]->get("missing");
+        FAIL() << "Expected YamlUnknownKeyError";
+    } catch (const YamlUnknownKeyError & ex) {
+        EXPECT_THAT(std::string(ex.what()), ::testing::HasSubstr("x86_64[0].missing"));
+    }
+}
+
 TEST(YamlNodeTest, ParseNodeFromYaml) {
     YamlNode node(YAML::Load("string_item: \"value\""));
     EXPECT_EQ("value", node.get("string_item")->as_string());


### PR DESCRIPTION
Previously, parsing the following libpkgmanifest infile:

```
document: rpm-package-input
version: 0.0.2
repositories:
packages:
archs:
    - x86_64
```

threw:
"An error occurred during parsing of the input file at "packages.input.yaml": Unknown key: install".

"Unknown key" implies an unexpected key was present, however the problem is that a required key was not present. The full path to the missing field is also missing, so the user doesn't know what object is missing the "install" field.

With this change, the error message reads:
An error occurred during parsing of the input file at "packages.input.yaml": Missing field: packages.install